### PR TITLE
Flushing the log only completes when the sinks have finished outputting log events

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dist/bower"]
-	path = dist/bower
-url=https://github.com/structured-log/structured-log-dev-bower

--- a/src/core/structured-log.js
+++ b/src/core/structured-log.js
@@ -484,7 +484,7 @@
             flushBatch = function () {
                 // Flush the batch.
                 batchedLogEvents.reverse();
-                next(batchedLogEvents);
+                next(batchedLogEvents); // Allow the log events to flow to the next stage to of the pipeline.
 
                 batchedLogEvents = [];
                 lastFlushTime = curTime;

--- a/src/core/structured-log.js
+++ b/src/core/structured-log.js
@@ -24,6 +24,43 @@
     root.structuredLog = factory();
   }
 }(this, function () {
+
+    //
+    // Throws an exception if the passed-in value is not a string.
+    //
+    function expectString(val) {
+        if (!val || typeof val !== 'string') {
+            throw new Error("Expected " + typeof(val) + " to be a string.");
+        }
+    };
+
+    //
+    // Throws an exception if the passed-in value is not a function.
+    //
+    function expectFunction(val) {
+        if (!val || typeof val !== 'function') {
+            throw new Error("Expected " + typeof(val) + " to be a function.");
+        }
+    };
+
+    //
+    // Throws an exception if the passed-in value is not an object.
+    //
+    function expectObject(val) {
+        if (!val || typeof val !== 'object') {
+            throw new Error("Expected " + typeof(val) + " to be an object.");
+        }
+    };
+
+    //
+    // Throws an exception if the passed-in value is not an array.
+    //
+    function expectArray(val) {        
+        if (!val || Object.prototype.toString.call(val) !== '[object Array]') {
+            throw new Error("Expected " + typeof(val) + " to be an array.");
+        }
+    };
+
   function MessageTemplate(messageTemplate) {
     var self = this;
 
@@ -208,318 +245,871 @@
     return self.levels[level || 'NONE'] || false;
   };
 
-
-  function Pipeline(pipelineStages, closeStages, flushStages) {
-    var self = this;
-    self.pipelineStages = pipelineStages;
-    self.closeStages = closeStages || [];
-    self.flushStages = flushStages || [];
-
-    var head = function(evts) { };
-    var makeHead = function(pipelineStage) {
-      var oldHead = head;
-      return function(evts) { 
-        pipelineStage(evts, oldHead); 
-      };
-    };
-
-    for (var i = self.pipelineStages.length - 1; i >= 0; --i) {
-      head = makeHead(self.pipelineStages[i]);
-    }
-    self.head = head;
-  }
-
-  Pipeline.prototype.execute = function(evts) {
-    var self = this;
-    self.head(evts);
-  };
-
-  Pipeline.prototype.close = function(cb) {
-    var self = this;
-    var remaining = self.closeStages.length;
-    if (remaining === 0) {
-      cb();
-      return;
-    }
-    var onClosed = function() {
-      remaining--;
-      if (remaining === 0) {
-        cb();
-      }
-    };
-    self.closeStages.forEach(function (closeStage) {
-      closeStage(onClosed);
-    });
-  };
-
-    // 
-    // Flush the pipeline.
-    // After completion the queue of batched logs will have been flushed through to all sinks.
     //
-    Pipeline.prototype.flush = function (cb) {
+    // Run several async functions in parallel, invoke a callback when they are done.
+    //
+    var runAsyncParallel = function () {
+
+        var done = arguments[arguments.length-1];
+        expectFunction(done);
+
+        if (arguments.length <= 1) {
+            done();
+            return;
+        }
+
+        var awaitingCompletion = arguments.length-1;
+        var allDone = false;
+
+        //
+        // Fire the final callback if all async fns have completed.
+        //
+        var checkAllDone = function () {
+            if (allDone) {
+                // Already completed all.
+                return;
+            }
+
+            --awaitingCompletion;
+            if (awaitingCompletion <= 0) {
+                allDone = true;
+                done();
+            }
+        };
+
+        for (var i = 0; i < arguments.length-1; ++i) {
+            var fn = arguments[i];
+            expectFunction(fn);
+
+            fn(checkAllDone);
+        }
+    };
+
+    //
+    // Represents a stage in the pipeline.
+    // Each state controls the flow to the next stage.
+    // This stage wraps a user-defined sink.
+    //
+    var SinkStage = function (sinkName, sinkEmit, sinkFlush, sinkClose, onError) {
+        expectString(sinkName);
+        expectFunction(sinkEmit);
+        if (sinkFlush) {
+            expectFunction(sinkFlush);
+        }
+        if (sinkClose) {
+            expectFunction(sinkClose);
+        }
+        if (onError) {
+            expectFunction(onError);
+        }
+
         var self = this;
-        var remaining = self.flushStages.length;
-        if (remaining === 0) {
-          cb();
-          return;
-        }
-        var onFlushed = function() {
-          remaining--;
-          if (remaining === 0) {
-            cb();
-          }
-        };
-        self.flushStages.forEach(function (flushStage) {
-          flushStage(onFlushed);
-        });
-    };
-
-
-  var createLogger = function(levelMap, pipeline) {
-    var self = function() {
-      self.info.apply(null, arguments);
-    };
-
-    self.toString = function() { return 'Logger'; };
-
-    self.emit = function(evts) {
-      evts = evts.filter(function (evt) { //todo: is this tested?
-          return levelMap.isEnabled(evt.level);
-        });
-
-      pipeline.execute(evts);
-    };
-
-    var invoke = function(level, messageTemplate, args) {
-      if (!levelMap.isEnabled(level)) {
-        return;
-      }
-
-      // Template caching opportunity here
-      var parsedTemplate = new MessageTemplate(messageTemplate);
-      var boundProperties = parsedTemplate.bindProperties(args);
-
-      var evt = new LogEvent(new Date(), level, parsedTemplate, boundProperties);
-
-      pipeline.execute([evt]);
-    };
-
-    self.verbose = function(messageTemplate) {
-      var mt = Array.prototype.shift.call(arguments);
-      invoke(verboseLevel, mt, arguments);
-    };
-
-    self.debug = function(messageTemplate) {
-      var mt = Array.prototype.shift.call(arguments);
-      invoke(debugLevel, mt, arguments);
-    };
-
-    self.info = function(messageTemplate) {
-      var mt = Array.prototype.shift.call(arguments);
-      invoke(infoLevel, mt, arguments);
-    };
-
-    self.warn = function(messageTemplate) {
-      var mt = Array.prototype.shift.call(arguments);
-      invoke(warnLevel, mt, arguments);
-    };
-
-    self.error = function(messageTemplate) {
-      var mt = Array.prototype.shift.call(arguments);
-      invoke(errorLevel, mt, arguments);
-    };
-
-    self.enrich = function(properties, destructure){
-      var enriched = new Pipeline([
-        function (evts, next){
-          enrich(evts, properties, destructure);
-          pipeline.execute(evts);
-          next(evts);
-        }
-      ]);
-      return createLogger(levelMap, enriched);
-    };
-
-    self.close = function(cb) {
-      pipeline.close(cb);
-    };
-
-    // 
-    // Flush the pipeline.
-    // After completion the queue of batched logs will have been flushed through to all sinks.
-    //
-    self.flush = function (cb) {
-        pipeline.flush(cb);
-    };
-
-    return self;
-  };
-
-
-  function LoggerConfiguration() {
-    var self = this;
-
-    var minLevel = infoLevel;
-    var pipeline = [];
-    var closeStages = [];
-    var flushStages = [];
-
-    self.pipe = function(pipelineStage) {
-      pipeline.push(pipelineStage);
-      return self;
-    };
-
-    self.minLevel = function(lvl) {
-      if (pipeline.length !== 0) {
-        var lm = new LevelMap(lvl);
-        return self.filter(function (evt) {
-            return lm.isEnabled(evt.level);
-          });
-      }
-
-      minLevel = (lvl || infoLevel).toUpperCase();
-      return self;
-    };
-
-    self.writeTo = function(sinkOrEmit, onError) {
-      if (typeof sinkOrEmit.emit !== 'function' && typeof sinkOrEmit === 'function') {
-        return self.writeTo({
-          emit: sinkOrEmit,
-          toString: function() { return sinkOrEmit.toString(); }
-        }, minLevel);
-      }
-
-      if (typeof sinkOrEmit.close === 'function') {
-        closeStages.push(sinkOrEmit.close);
-      }
-
-      return self.pipe(function(evts, next) {
-        try {
-          sinkOrEmit.emit(evts);
-        } 
-        catch (err) {
-          if (typeof onError === 'function') {
-            onError(err, evts, next);
-          } 
-          else {
-            var notification = createEvent(errorLevel, 'Failed to write to {sink}: {error}', sinkOrEmit, err.stack);
-            notification.properties.isSelfLog = true;
-            next([notification]);
-          }
-        }
-        next(evts);        
-      });
-    };
-
-    self.enrich = function(functionOrProperties, destructure) {
-      if (typeof functionOrProperties === 'object') {
-        return self.enrich(function(evts){
-            return functionOrProperties;
-          }, destructure);
-      } else if (typeof functionOrProperties === 'function') {
-        return self.pipe(function(evts, next) {
-          enrich(evts, functionOrProperties(), destructure);
-          next(evts);
-        });
-      } else {
-        throw new Error('Events can be enriched using either a function, or a hash of properties');
-      }
-    };
-
-    self.filter = function (filter) {
-      return self.pipe(function (evts, next) {
-          next(evts.filter(filter));
-        });
+        this.sinkName = sinkName;
+        self.sinkEmit = sinkEmit;
+        self.sinkFlush = sinkFlush;
+        self.sinkClose = sinkClose;
+        self.onError = onError;
     };
 
     //
-    // Enable batching for sinks in the pipeline after this function.
+    // Set the next pipeline stage.
     //
-    self.batch = function (batchOptions) {
+    SinkStage.prototype.setNextStage = function (nextStage) {
+        expectObject(nextStage);
 
-        if (!batchOptions) {
-            batchOptions = {};    
+        var self = this;
+        self.nextStage = nextStage;        
+    };
+
+    //
+    // Convert an error message or object to string for logging.
+    //
+    var errToString = function (err) {
+        if (typeof(err) === 'string') {
+            return err;
         }
-
-        if (!batchOptions.batchSize) {
-            batchOptions.batchSize = 100;
+        else if (err.stack) {
+            return err.stack.toString();
         }
-
-        if (!batchOptions.timeDuration) {
-            batchOptions.timeDuration = 1000;
+        else {
+            return err.toString();
         }
+    };
 
-        var batchedLogEvents = [];
-        var lastFlushTime = (new Date()).getTime();
+    //
+    // Emit log events to the pipeline state.
+    // The stage itself controls the flow to the next stage.
+    //
+    SinkStage.prototype.emit = function (logEvts, done) {
+        expectArray(logEvts);
+        expectFunction(done);
 
-        var flushBatch = null;
-        var batchFlushTimeout = null; // Used to cancel the pending flush.        
+        var self = this;
 
         //
-        // Flush the batch when the log is flushed or closed.
+        // Emit logs to the sink.
         //
-        var flushStage = function (callback) {
-
-            if (flushBatch) {
-                flushBatch();
+        var sinkEmit = function (done) {
+            try
+            {
+                if (self.sinkEmit.length > 1) {
+                    // First parameter is async callback.
+                    self.sinkEmit(logEvts, done);
+                }
+                else {
+                    // Synchronous flush fn.
+                    self.sinkEmit(logEvts);
+                    done();
+                }
             }
-
-            callback();
+            catch (err) {
+                // Emit sink related errors to the next stage.
+                if (typeof self.onError === 'function') {
+                    self.onError(err, logEvts, done);
+                } 
+                else if (self.nextStage) {
+                    var errLogEvt = createEvent(errorLevel, 'Failed to write to {sink}: {error}', self.sinkName, errToString(err));
+                    errLogEvt.properties.isSelfLog = true;
+                    self.nextStage.emit([errLogEvt], done);
+                }
+                else {
+                    // There is no next stage.
+                    // todo: These errors get lost, need to do something about this!!
+                    done();
+                }
+            }
         };
 
-        closeStages.push(flushStage);
-        flushStages.push(flushStage);
-
-        return self.pipe(function (evts, next) {
-
-            if (batchFlushTimeout) {
-                // Cancel previous pending batch flush.
-                clearTimeout(batchFlushTimeout);
-                batchFlushTimeout = null;
+        //
+        // Emit logs to next stage.
+        //
+        var nextStageEmit = function (done) {
+            if (self.nextStage) {
+                self.nextStage.emit(logEvts, done);
             }
+            else {
+                done();
+            }           
+        };
+
+        runAsyncParallel(sinkEmit, nextStageEmit, done);
+    };
+
+    //
+    // Flush the log stage.
+    //
+    SinkStage.prototype.flush = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        // 
+        // Call the sink's flush fn.
+        //
+        var sinkFlush = function (done) {
+            if (!self.sinkFlush) {
+                // Sink doesn't have a flush fn.
+                done();
+            }
+            else if (self.sinkFlush.length > 0) {
+                // First parameter is async callback.
+                self.sinkFlush(done);
+            }
+            else {
+                // Synchronous flush fn.
+                self.sinkFlush();
+                done();
+            }
+        };
+
+        //
+        // Flush the next stage.
+        var nextStageFlush = function (done) {
+            if (self.nextStage) {
+                self.nextStage.flush(done);
+            }
+            else {
+                done();
+            }
+        };
+
+        runAsyncParallel(sinkFlush, nextStageFlush, done);
+    };
+
+    //
+    // Close the log stage.
+    //
+    SinkStage.prototype.close = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Flush before closing.
+        //
+        self.flush(function () {
 
             // 
-            // Flush the batch.
+            // Close the sink.
             //
-            flushBatch = function () {
-                // Flush the batch.
-                batchedLogEvents.reverse();
-                next(batchedLogEvents); // Allow the log events to flow to the next stage to of the pipeline.
-
-                batchedLogEvents = [];
-                lastFlushTime = curTime;
-                batchFlushTimeout = null;
-                flushBatch = null;
+            var sinkClose = function (done) {
+                if (!self.sinkClose) {
+                    // Sink doesn't have a close fn.
+                    done();
+                }
+                else if (self.sinkClose.length > 0) {
+                    // First parameter is async callback.
+                    self.sinkClose(done);
+                }
+                else {
+                    // Synchronous close fn.
+                    self.sinkClose();
+                    done();
+                }
             };
 
-            // Queue pending batch flush.
-            batchFlushTimeout = setTimeout(flushBatch, batchOptions.timeDuration);
-
-            evts.forEach(function (evt) { //todo: is there a more efficient way?
-                batchedLogEvents.push(evt);
-            });            
-
-            var curTime = (new Date()).getTime();
-
-            if (batchedLogEvents.length >= batchOptions.batchSize ||
-                batchOptions.timeDuration && (curTime - lastFlushTime) > batchOptions.timeDuration) {
-
-                if (batchFlushTimeout) {
-                    // Cancel previous pending batch flush.
-                    clearTimeout(batchFlushTimeout);
-                    batchFlushTimeout = null;
+            //
+            // Close the next stage.
+            //
+            var nextStageClose = function (done) {
+                if (self.nextStage) {
+                    self.nextStage.close(done);
                 }
+                else {
+                    // There is no next stage.
+                    done();
+                }
+            };
 
-                flushBatch();
-            }
+            runAsyncParallel(sinkClose, nextStageClose, done);
         });
     };
 
-    self.create = function() {
-      var levelMap = new LevelMap(minLevel);
-      return createLogger(levelMap, new Pipeline(pipeline, closeStages, flushStages));
+    //
+    // Represents a stage in the pipeline.
+    // Each state controls the flow to the next stage.
+    // This stage batches log events until they are flushed through the system.
+    //
+    var BatchStage = function (config) {
+        expectObject(config);
+
+        var self = this;
+        self.config = config;
+        self.batchedLogEvts = [];
+        self.lastFlushTime = (new Date()).getTime();
+
+        //
+        // Set default batching values.
+        //
+
+        if (!self.config.batchSize) {
+            self.config.batchSize = 100;
+        }
+
+        if (!self.config.timeDuration) {
+            self.config.timeDuration = 1000;
+        }
     };
-  }
+
+    //
+    // Set the next pipeline stage.
+    //
+    BatchStage.prototype.setNextStage = function (nextStage) {
+        expectObject(nextStage);
+
+        var self = this;
+
+        self.nextStage = nextStage;        
+    };
+
+    //
+    // Flush batched logs to the next stage in the pipeline.
+    //
+    BatchStage.prototype.flushBatch = function (done) {        
+        expectFunction(done);
+
+        var self = this;
+
+        // Time to flush logs to the next stage of the pipeline.
+        self.nextStage.emit(self.batchedLogEvts, done);
+        self.batchedLogEvts = [];
+    };
+
+    //
+    // Start the flush timer .
+    //
+    BatchStage.prototype.startFlushTimer = function () {
+    
+        var self = this;
+
+        self.batchFlushTimer = setTimeout(function () {
+
+                self.flushBatch(function () {}); //todo: don't want empty fn.
+
+            }, self.config.timeDuration);
+    };
+
+    //
+    // Cancel the flush timer.
+    //
+    BatchStage.prototype.cancelFlushTimer = function () {
+
+        var self = this;   
+
+        if (self.batchFlushTimer) {
+            // Cancel the flush timeout.
+            clearTimeout(self.batchFlushTimer);
+            self.batchFlushTimer = null;
+        }
+    };
+
+    //
+    // Emit log events to the pipeline state.
+    // The stage itself controls the flow to the next stage.
+    //
+    BatchStage.prototype.emit = function (logEvts, done) { //todo: init timeout.
+        expectArray(logEvts);
+        expectFunction(done);
+
+        var self = this;
+
+        self.cancelFlushTimer();
+
+        var curTime = (new Date()).getTime();
+
+        self.batchedLogEvts = self.batchedLogEvts.concat(logEvts);
+
+        var needsFlushNow = 
+            self.batchedLogEvts.length >= self.config.batchSize ||
+            self.config.timeDuration && (self.curTime - self.lastFlushTime) > self.config.timeDuration;
+
+        if (needsFlushNow) {
+            self.flushBatch(function () {}); //todo: don't want an empty fn here.
+        }
+        else {
+            self.startFlushTimer();
+
+            // Buffered logs, indicate emit is done.
+            done();
+        }
+    };
+
+    //
+    // Flush the log stage.
+    //
+    BatchStage.prototype.flush = function (done) { //todo: reset timeout
+        expectFunction(done);
+
+        var self = this;
+
+        if (self.batchedLogEvts.length > 0) {
+            // Emit batched logs to the next stage.
+            self.nextStage.emit(self.batchedLogEvts, function () {
+                // Flush the next stage.
+                self.nextStage.flush(done);
+            });
+            self.batchedLogEvts = [];
+        }
+        else {
+            // No logs are batched.
+            // Flush the next stage.
+            self.nextStage.flush(done);
+        }            
+    };
+
+    //
+    // Close the log stage.
+    //
+    BatchStage.prototype.close = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Flush this stage first.
+        //
+        self.flush(function () {
+            //
+            // Close the next stage.
+            //
+            self.nextStage.close(done);
+        })
+    };    
+
+    //
+    // Represents a filtering stage in the pipeline.
+    // Each state controls the flow to the next stage.
+    //
+    var FilterStage = function (filterPredicate) {
+        expectFunction(filterPredicate);
+
+        var self = this;
+        self.filterPredicate = filterPredicate;
+    };
+
+    //
+    // Set the next pipeline stage.
+    //
+    FilterStage.prototype.setNextStage = function (nextStage) {
+        expectObject(nextStage);
+
+        var self = this;
+
+        self.nextStage = nextStage;        
+    };
+
+    //
+    // Emit log events to the pipeline state.
+    // The stage itself controls the flow to the next stage.
+    //
+    FilterStage.prototype.emit = function (logEvts, done) {
+        expectArray(logEvts);
+        expectFunction(done);
+
+        var self = this;
+        var filteredLogEvts = logEvts.filter(self.filterPredicate);
+        if (filteredLogEvts.length > 0) {
+            // Pass filtered logs onto next stage.
+            self.nextStage.emit(filteredLogEvts, done);
+            return;
+        }
+    };
+
+    //
+    // Flush the log stage.
+    //
+    FilterStage.prototype.flush = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        // Flush the next stage.
+        self.nextStage.flush(done);
+    };
+
+    //
+    // Close the log stage.
+    //
+    FilterStage.prototype.close = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Flush this stage first.
+        //
+        self.flush(function () {
+            //
+            // Close the next stage.
+            //
+            self.nextStage.close(done);
+        });
+    };    
+
+    //
+    // Represents a stage in the pipeline that adds properties.
+    // Each state controls the flow to the next stage.
+    //
+    var EnrichStage = function (enrichFn, destructure) {
+        expectFunction(enrichFn);
+
+        var self = this;
+
+        self.enrichFn = enrichFn;
+        self.destructure = destructure;
+    };
+
+    //
+    // Set the next pipeline stage.
+    //
+    EnrichStage.prototype.setNextStage = function (nextStage) {
+        expectObject(nextStage);
+
+        var self = this;
+
+        self.nextStage = nextStage;        
+    };
+
+    //
+    // Emit log events to the pipeline state.
+    // The stage itself controls the flow to the next stage.
+    //
+    EnrichStage.prototype.emit = function (logEvts, done) {
+        expectArray(logEvts);
+        expectFunction(done);
+
+        var self = this;
+
+        enrich(logEvts, self.enrichFn(), self.destructure);
+
+        // Pass on to next stage.
+        self.nextStage.emit(logEvts, done);
+    };
+
+    //
+    // Flush the log stage.
+    //
+    EnrichStage.prototype.flush = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        // Flush the next stage.
+        self.nextStage.flush(done);
+    };
+
+    //
+    // Close the log stage.
+    //
+    EnrichStage.prototype.close = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Flush this stage first.
+        //
+        self.flush(function () {
+            //
+            // Close the next stage.
+            //
+            self.nextStage.close(done);
+        });
+    };    
+
+    //
+    // A pipeline stage that passed to another pipeline.
+    //
+    var SubPipelineStage = function (pipeline) {
+        expectObject(pipeline);
+
+        var self = this;
+        
+        self.pipeline = pipeline;
+    };
+
+    //
+    // Set the next pipeline stage.
+    //
+    SubPipelineStage.prototype.setNextStage = function (nextStage) {
+        expectObject(nextStage);
+
+        var self = this;
+
+        self.nextStage = nextStage;        
+    };
+
+    //
+    // Emit log events to the pipeline stage.
+    // The stage itself controls the flow to the next stage.
+    //
+    SubPipelineStage.prototype.emit = function (logEvts, done) {
+        expectArray(logEvts);
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Emit logs to the next pipeline.
+        //
+        var pipelineEmit = function (done) {
+            self.pipeline.emit(logEvts, done);
+        };
+
+        //
+        // Emit logs to next stage.
+        //
+        var nextStageEmit = function (done) {
+            if (self.nextStage) {
+                self.nextStage.emit(logEvts, done);
+            }
+            else {
+                done();
+            }           
+        };
+
+        runAsyncParallel(pipelineEmit, nextStageEmit, done);
+    };
+
+    //
+    // Flush the log stage.
+    //
+    SubPipelineStage.prototype.flush = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        // 
+        // Call the pipelines's flush fn.
+        //
+        var pipelineFlush = function (done) {
+            self.pipeline.flush(done);
+        };
+
+        //
+        // Flush the next stage.
+        var nextStageFlush = function (done) {
+            if (self.nextStage) {
+                self.nextStage.flush(done);
+            }
+            else {
+                done();
+            }
+        };
+
+        runAsyncParallel(pipelineFlush, nextStageFlush, done);        
+    };
+
+    //
+    // Close the log stage.
+    //
+    SubPipelineStage.prototype.close = function (done) {
+        expectFunction(done);
+
+        var self = this;
+
+        //
+        // Flush before closing.
+        //
+        self.flush(function () {
+
+            // 
+            // Close the pipeline.
+            //
+            var pipelineClose = function (done) {
+                self.pipeline.close(done);
+            };
+
+            //
+            // Close the next stage.
+            //
+            var nextStageClose = function (done) {
+                if (self.nextStage) {
+                    self.nextStage.close(done);
+                }
+                else {
+                    // There is no next stage.
+                    done();
+                }
+            };
+
+            runAsyncParallel(pipelineClose, nextStageClose, done);
+        });
+    };    
+
+
+    function Pipeline(pipelineStages) {
+        expectArray(pipelineStages);
+
+        if (pipelineStages.length < 1) {
+            throw new Error("No pipeline stages defined!");
+        }
+
+        var self = this;
+        self.pipelineStages = pipelineStages;
+        self.headStage = self.pipelineStages[0];
+
+        // 
+        // Connect the stages of the pipeline.
+        //
+        for (var stageIndex = 0; stageIndex < self.pipelineStages.length-1; ++stageIndex) {
+            var nextStage = self.pipelineStages[stageIndex+1];
+            var stage = self.pipelineStages[stageIndex].setNextStage(nextStage);
+        }
+    };
+
+    //
+    // Emit log events to the pipeline.
+    //
+    Pipeline.prototype.emit = function (logEvts, done) {
+        var self = this;
+        self.headStage.emit(logEvts, done);
+    };
+
+    // 
+    // Flush the pipeline.
+    // After completion the queue of batched logs will have been flushed through to all sinks.
+    //
+    Pipeline.prototype.flush = function (done) {
+        var self = this;
+        self.headStage.flush(done);
+    };
+
+    //
+    // Close the pipeline and all sinks.
+    //
+    Pipeline.prototype.close = function(done) {
+        var self = this;
+        self.headStage.close(done);
+    };
+
+    //
+    // Factory function for a logger.
+    //
+    var createLogger = function(levelMap, pipeline) {
+        var self = function() {
+            self.info.apply(null, arguments);
+        };
+
+        self.toString = function() { return 'Logger'; };
+
+        self.emit = function(logEvts) {
+            logEvts = logEvts.filter(function (evt) {
+                    return levelMap.isEnabled(evt.level);
+                });
+
+            pipeline.emit(logEvts, function () {}); //todo: don't create fn for no reason
+        };
+
+        var invoke = function(level, messageTemplate, args) {
+            if (!levelMap.isEnabled(level)) {
+                return;
+            }
+
+            // Template caching opportunity here
+            var parsedTemplate = new MessageTemplate(messageTemplate);
+            var boundProperties = parsedTemplate.bindProperties(args);
+
+            var evt = new LogEvent(new Date(), level, parsedTemplate, boundProperties);
+            pipeline.emit([evt], function () {});  //todo: don't create fn for no reason
+        };
+
+        self.verbose = function(messageTemplate) {
+            var mt = Array.prototype.shift.call(arguments);
+            invoke(verboseLevel, mt, arguments);
+        };
+
+        self.debug = function(messageTemplate) {
+            var mt = Array.prototype.shift.call(arguments);
+            invoke(debugLevel, mt, arguments);
+        };
+
+        self.info = function(messageTemplate) {
+            var mt = Array.prototype.shift.call(arguments);
+            invoke(infoLevel, mt, arguments);
+        };
+
+        self.warn = function(messageTemplate) {
+            var mt = Array.prototype.shift.call(arguments);
+            invoke(warnLevel, mt, arguments);
+        };
+
+        self.error = function(messageTemplate) {
+            var mt = Array.prototype.shift.call(arguments);
+            invoke(errorLevel, mt, arguments);
+        };
+
+        self.enrich = function(properties, destructure) {
+
+            var enrichedPipeline = new Pipeline([
+                new EnrichStage(function () { return properties; }, destructure),
+                new SubPipelineStage(pipeline)
+            ]);
+            return createLogger(levelMap, enrichedPipeline);
+        };
+
+        // 
+        // Flush the pipeline.
+        // After completion the queue of batched logs will have been flushed through to all sinks.
+        //
+        self.flush = function (done) {
+            pipeline.flush(done);
+        };
+
+        //
+        // Close (and flush) the logger.
+        //
+        self.close = function(done) {
+            pipeline.close(done);
+        };
+
+
+        return self;
+    };
+
+
+    function LoggerConfiguration() {
+        var self = this;
+
+        var minLevel = infoLevel;
+        var pipelineStages = [];
+
+        //
+        // Add a stage to the pipeline.
+        //
+        self.addStage = function(pipelineStage) {
+            expectObject(pipelineStage);
+            
+            pipelineStages.push(pipelineStage);
+            return self;
+        };
+
+        //
+        // Specify a minimum log level to output.
+        //
+        self.minLevel = function(lvl) {
+            if (pipelineStages.length !== 0) {
+                var lm = new LevelMap(lvl);
+                return self.filter(function (evt) {
+                    return lm.isEnabled(evt.level);
+                });
+            }
+
+            minLevel = (lvl || infoLevel).toUpperCase();
+            return self;
+        };
+
+        //
+        // Write log events to a sink.
+        //
+        self.writeTo = function(sinkOrEmit, onError) {
+            if (typeof sinkOrEmit.emit !== 'function' && typeof sinkOrEmit === 'function') {
+                return self.writeTo(
+                    {
+                        emit: sinkOrEmit,
+                        toString: function() { 
+                            return "function";
+                        }
+                    },
+                    onError
+                );
+            }
+
+            return self.addStage(new SinkStage(sinkOrEmit.toString(), sinkOrEmit.emit, sinkOrEmit.flush, sinkOrEmit.close, onError));
+        };
+
+        self.enrich = function(functionOrProperties, destructure) {
+            if (typeof functionOrProperties === 'object') {
+                return self.enrich(function (){
+                        return functionOrProperties;
+                    }, destructure);
+            } 
+            else if (typeof functionOrProperties === 'function') {
+                return self.addStage(new EnrichStage(functionOrProperties, destructure));
+            } 
+            else {
+                throw new Error('Events can be enriched using either a function, or a hash of properties');
+            }
+        };
+
+        self.filter = function (filter) {
+            return self.addStage(new FilterStage(filter));
+        };
+
+        //
+        // Enable batching for sinks in the pipeline after this function.
+        //
+        self.batch = function (batchOptions) {
+            return self.addStage(new BatchStage(batchOptions || {}));
+        };
+
+        //
+        // Create a logger from the log configuration.
+        //
+        self.create = function() {
+            return createLogger(new LevelMap(minLevel), new Pipeline(pipelineStages));
+        };
+    }
 
 
   function StructuredLog() {


### PR DESCRIPTION
This PR changes flushing behaviour so that the flush complete (doesn't invoke the callback) until all sinks have finished outputting log events. 

This was achieved through a large refactor to the way the pipeline stages are defined.

The pipeline stages are now easier to understand and more flexible. It will be easier to define new pipeline stages and evolve the system.

There are still some issues (noted in my todo list) and there is more refactoring todo (such as moving each type of pipeline stage to its own file).  However all tests pass including a new test for the new behaviour of the flush function.