### PR TITLE
Update license to match SPDX name

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "semantic"
   ],
   "author": "Serilog Contributors",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/structured-log/structured-log.js/issues"
   },


### PR DESCRIPTION
This is to resolve the warning travis is throwing